### PR TITLE
MANATEE-371 Want ISM for SysV Shared Memory in Postgres >= 9.3

### DIFF
--- a/src/backend/port/sysv_shmem.c
+++ b/src/backend/port/sysv_shmem.c
@@ -56,15 +56,20 @@
  * false, we might need to add compile and/or run-time tests here and do this
  * only if the running kernel supports it.
  *
- * However, we must always disable this logic in the EXEC_BACKEND case, and
+ * There are two cases in which we disable this logic. On systems that support
+ * intimate shared memory (e.g. illumos and Solaris), we prefer the usage of
+ * System V shared memory in order to take advantage of the performance
+ * improvements that sharing page tables provides.
+ *
+ * In addition, we must always disable this logic in the EXEC_BACKEND case, and
  * fall back to the old method of allocating the entire segment using System V
  * shared memory, because there's no way to attach an anonymous mmap'd segment
  * to a process after exec().  Since EXEC_BACKEND is intended only for
  * developer use, this shouldn't be a big problem.  Because of this, we do
  * not worry about supporting anonymous shmem in the EXEC_BACKEND cases below.
  */
-#ifndef EXEC_BACKEND
-#define USE_ANONYMOUS_SHMEM
+#if !defined(EXEC_BACKEND) && !defined(SHM_SHARE_MMU)
+#  define USE_ANONYMOUS_SHMEM
 #endif
 
 

--- a/src/bin/initdb/initdb.c
+++ b/src/bin/initdb/initdb.c
@@ -863,12 +863,13 @@ set_null_conf(void)
  * attempt to reproduce what the postmaster will do when allocating a POSIX
  * segment in dsm_impl.c; if it doesn't work, we assume it won't work for
  * the postmaster either, and configure the cluster for System V shared
- * memory instead.
+ * memory instead. However, on Solaris-derived systems, System V shared
+ * memory is preferred.
  */
 static char *
 choose_dsm_implementation(void)
 {
-#ifdef HAVE_SHM_OPEN
+#if defined(HAVE_SHM_OPEN) && !defined(__sun)
 	int			ntries = 10;
 
 	while (ntries > 0)

--- a/src/include/storage/dsm_impl.h
+++ b/src/include/storage/dsm_impl.h
@@ -23,20 +23,22 @@
 /*
  * Determine which dynamic shared memory implementations will be supported
  * on this platform, and which one will be the default.
+ * Note for systems which feature SHM_SHARE_MMU (e.g. illumos and Solaris)
+ * we prefer to System V Shared Memory instead of POSIX.
  */
 #ifdef WIN32
-#define USE_DSM_WINDOWS
-#define DEFAULT_DYNAMIC_SHARED_MEMORY_TYPE		DSM_IMPL_WINDOWS
-#else
-#ifdef HAVE_SHM_OPEN
-#define USE_DSM_POSIX
-#define DEFAULT_DYNAMIC_SHARED_MEMORY_TYPE		DSM_IMPL_POSIX
-#endif
-#define USE_DSM_SYSV
-#ifndef DEFAULT_DYNAMIC_SHARED_MEMORY_TYPE
-#define DEFAULT_DYNAMIC_SHARED_MEMORY_TYPE		DSM_IMPL_SYSV
-#endif
-#define USE_DSM_MMAP
+#    define USE_DSM_WINDOWS
+#    define DEFAULT_DYNAMIC_SHARED_MEMORY_TYPE		DSM_IMPL_WINDOWS
+#  else
+#    ifdef HAVE_SHM_OPEN
+#      define USE_DSM_POSIX
+#      define DEFAULT_DYNAMIC_SHARED_MEMORY_TYPE	DSM_IMPL_POSIX
+#    endif
+#    define USE_DSM_SYSV
+#    if !defined(DEFAULT_DYNAMIC_SHARED_MEMORY_TYPE) || defined(SHM_SHARE_MMU)
+#      define DEFAULT_DYNAMIC_SHARED_MEMORY_TYPE	DSM_IMPL_SYSV
+#    endif
+#    define USE_DSM_MMAP
 #endif
 
 /* GUC. */


### PR DESCRIPTION
This bug is described here: [MANATEE-371](https://smartos.org/bugview/MANATEE-371).

This bug changes the default shared memory API to System V Shared Memory instead of POSIX on Solaris-derived Operating Systems such as illumos. In addition it changes the behavior of System V Shared Memory to take advantage of intimate shared memory on such systems, the default behavior of Postgres prior to Postgres 9.3.